### PR TITLE
add Javadoc step, add Java 8 & 11 matrix build, cleanup names

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,21 @@
+# This is a basic workflow to help you get started with Actions
+
+name: DCO
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: DCO-Check
+      uses: tim-actions/dco@v1.0
+      with:
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,6 +38,8 @@ jobs:
       run: ./gradlew assemble
     - name: Check with Gradle
       run: ./gradlew check
+    - name: Javadoc with Gradle
+      run: ./gradlew javadocs
     - name: Codecov
       uses: codecov/codecov-action@v1.0.12
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Cache
+    - name: Restore local Gradle & Maven cache
       uses: actions/cache@v2.1.0
       with:
         # A list of files, directories, and wildcard patterns to cache and restore
@@ -34,7 +34,7 @@ jobs:
         java-version: 1.8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build with Gradle
+    - name: Assemble with Gradle
       run: ./gradlew assemble
     - name: Check with Gradle
       run: ./gradlew check

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
 
+    name: Java ${{ matrix.java }} build
     steps:
     - uses: actions/checkout@v1
     - name: Restore local Gradle & Maven cache
@@ -28,10 +32,10 @@ jobs:
         key: gradle-m2
         # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
         restore-keys: # optional
-    - name: Set up JDK 1.8
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Assemble with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,61 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache
+      uses: actions/cache@v2.1.0
+      with:
+        # A list of files, directories, and wildcard patterns to cache and restore
+        path: |
+          .gradle
+          ~/.gradle
+          ~/.m2
+        # An explicit key for restoring and saving the cache
+        key: gradle-m2
+        # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
+        restore-keys: # optional
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew assemble
+    - name: Check with Gradle
+      run: ./gradlew check
+    - name: Codecov
+      uses: codecov/codecov-action@v1.0.12
+      with:
+        # User defined upload name. Visible in Codecov UI
+        name: # optional
+        # Repository upload token - get it from codecov.io. Required only for private repositories
+        token: ${{ secrets.CODECOV_TOKEN }}
+        # Path to coverage file to upload
+        file: # optional
+        # Comma-separated list of files to upload
+        files: # optional
+        # Directory to search for coverage reports.
+        directory: # optional
+        # Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
+        flags: # optional
+        # Write upload file to path before uploading
+        path_to_write_report: # optional
+        # Environment variables to tag the upload with (e.g. PYTHON | OS,PYTHON)
+        env_vars: # optional
+        # Specify whether or not CI build should fail if Codecov runs into an error during upload
+        fail_ci_if_error: # optional


### PR DESCRIPTION
**Change log description**  
Add Javadoc step from Travis CI. Add Java 8 and Java 11 matrix build. Improve step names.

**Purpose of the change**  
Improve Actions CI.

**What the code does**  
Runs `javadocs` gradle task. Sets up a matrix of 8 & 11 to run steps in parallel.

**How to verify it**  
See this PR.
